### PR TITLE
Update Tascam_US-122.md (again)

### DIFF
--- a/lib/md/Tascam_US-122.md
+++ b/lib/md/Tascam_US-122.md
@@ -100,7 +100,7 @@ before the hardware dependent interface has been raised. If so,
 changing this second line to the following may provide a fix (it
 did for the author of this paragraph):
 
-    SUBSYSTEM=="sound", ACTION=="add", KERNEL=="hwC2D0", RUN+="/bin/sh -c '/usr/bin/usx2yloader'"
+    SUBSYSTEM=="sound", ACTION=="add", ATTR{id}=="USX2Y", RUN+="/bin/sh -c '/usr/bin/usx2yloader'"
 
 ### Audio Recording / Playback
 


### PR DESCRIPTION
As per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=844501 I've just realised that "hwC2D0" is "card-ordering-dependent". This change provides a solution which works independently of card order. Apologies for the noise. Jaime