### PR TITLE
Fix broken link to vendor product site

### DIFF
--- a/lib/md/Edirol_UA-4FX.md
+++ b/lib/md/Edirol_UA-4FX.md
@@ -947,7 +947,7 @@ See also
 --------
 
 -   vendor link:
-    [http://www.edirol.net/products/en/UA-4FX](http://www.edirol.net/products/en/UA-4FX)
+    [https://www.roland.com/global/support/by_product/ua-4fx/](https://www.roland.com/global/support/by_product/ua-4fx/)
 
 Retrieved from
 "[http://alsa.opensrc.org/Edirol\_UA-4FX](http://alsa.opensrc.org/Edirol_UA-4FX)"


### PR DESCRIPTION
http://www.edirol.net/products/en/UA-4FX returns a HTTP 404 error indicating it is not found.

https://www.roland.com/global/support/by_product/ua-4fx/ works and has all of related info of this now discontinued external sound card.